### PR TITLE
fix: flakey snippets RiskAnalysisTests#testLDiversity test + Dlp samples format's

### DIFF
--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableBucketing.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableBucketing.java
@@ -39,26 +39,30 @@ public class DeIdentifyTableBucketing {
   public static void deIdentifyTableBucketing() throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .build())
+            .build();
 
     deIdentifyTableBucketing(projectId, tableToDeIdentify);
   }
@@ -111,8 +115,7 @@ public class DeIdentifyTableBucketing {
       DeidentifyContentResponse response = dlp.deidentifyContent(request);
 
       // Print the results.
-      System.out.println(
-          "Table after de-identification: " + response.getItem().getTable());
+      System.out.println("Table after de-identification: " + response.getItem().getTable());
 
       return response.getItem().getTable();
     }

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableConditionInfoTypes.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableConditionInfoTypes.java
@@ -64,7 +64,7 @@ public class DeIdentifyTableConditionInfoTypes {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "Charles Dickens name was a curse, possibly invented by Shakespeare.")
+                                "Charles Dickens name was a curse invented by Shakespeare.")
                             .build())
                     .build())
             .addRows(

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableConditionInfoTypes.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableConditionInfoTypes.java
@@ -50,32 +50,41 @@ public class DeIdentifyTableConditionInfoTypes {
   public static void deIdentifyTableConditionInfoTypes() throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "Charles Dickens name was a curse, possibly invented by Shakespeare.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "There are 14 kisses in Jane Austen's novels.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue(
+                                "Charles Dickens name was a curse, possibly invented by Shakespeare.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue("There are 14 kisses in Jane Austen's novels.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
+                    .build())
+            .build();
 
     deIdentifyTableConditionInfoTypes(projectId, tableToDeIdentify);
   }
@@ -95,8 +104,10 @@ public class DeIdentifyTableConditionInfoTypes {
       // Specify that findings should be replaced with corresponding info type name.
       ReplaceWithInfoTypeConfig replaceWithInfoTypeConfig =
           ReplaceWithInfoTypeConfig.getDefaultInstance();
-      PrimitiveTransformation primitiveTransformation = PrimitiveTransformation.newBuilder()
-          .setReplaceWithInfoTypeConfig(replaceWithInfoTypeConfig).build();
+      PrimitiveTransformation primitiveTransformation =
+          PrimitiveTransformation.newBuilder()
+              .setReplaceWithInfoTypeConfig(replaceWithInfoTypeConfig)
+              .build();
       // Associate info type with the replacement strategy
       InfoTypeTransformation infoTypeTransformation =
           InfoTypeTransformation.newBuilder()
@@ -104,29 +115,29 @@ public class DeIdentifyTableConditionInfoTypes {
               .setPrimitiveTransformation(primitiveTransformation)
               .build();
       InfoTypeTransformations infoTypeTransformations =
-          InfoTypeTransformations.newBuilder()
-              .addTransformations(infoTypeTransformation)
-              .build();
+          InfoTypeTransformations.newBuilder().addTransformations(infoTypeTransformation).build();
 
       // Specify fields to be de-identified.
-      List<FieldId> fieldIds = Stream.of("PATIENT", "FACTOID")
-          .map(id -> FieldId.newBuilder().setName(id).build())
-          .collect(Collectors.toList());
+      List<FieldId> fieldIds =
+          Stream.of("PATIENT", "FACTOID")
+              .map(id -> FieldId.newBuilder().setName(id).build())
+              .collect(Collectors.toList());
 
       // Specify when the above fields should be de-identified.
-      Condition condition = Condition.newBuilder()
-          .setField(FieldId.newBuilder().setName("AGE").build())
-          .setOperator(RelationalOperator.GREATER_THAN)
-          .setValue(Value.newBuilder().setIntegerValue(89).build())
-          .build();
+      Condition condition =
+          Condition.newBuilder()
+              .setField(FieldId.newBuilder().setName("AGE").build())
+              .setOperator(RelationalOperator.GREATER_THAN)
+              .setValue(Value.newBuilder().setIntegerValue(89).build())
+              .build();
       // Apply the condition to records
-      RecordCondition recordCondition = RecordCondition.newBuilder()
-          .setExpressions(Expressions.newBuilder()
-              .setConditions(Conditions.newBuilder()
-                  .addConditions(condition)
-                  .build())
-              .build())
-          .build();
+      RecordCondition recordCondition =
+          RecordCondition.newBuilder()
+              .setExpressions(
+                  Expressions.newBuilder()
+                      .setConditions(Conditions.newBuilder().addConditions(condition).build())
+                      .build())
+              .build();
 
       // Associate the de-identification and conditions with the specified fields.
       FieldTransformation fieldTransformation =
@@ -153,8 +164,7 @@ public class DeIdentifyTableConditionInfoTypes {
       DeidentifyContentResponse response = dlp.deidentifyContent(request);
 
       // Print the results.
-      System.out.println(
-          "Table after de-identification: " + response.getItem().getTable());
+      System.out.println("Table after de-identification: " + response.getItem().getTable());
 
       return response.getItem().getTable();
     }

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableConditionMasking.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableConditionMasking.java
@@ -44,26 +44,30 @@ public class DeIdentifyTableConditionMasking {
   public static void deIdentifyTableConditionMasking() throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .build())
+            .build();
 
     deIdentifyTableConditionMasking(projectId, tableToDeIdentify);
   }
@@ -79,31 +83,28 @@ public class DeIdentifyTableConditionMasking {
 
       // Specify how the content should be de-identified.
       CharacterMaskConfig characterMaskConfig =
-          CharacterMaskConfig.newBuilder()
-              .setMaskingCharacter("*")
-              .build();
+          CharacterMaskConfig.newBuilder().setMaskingCharacter("*").build();
       PrimitiveTransformation primitiveTransformation =
-          PrimitiveTransformation.newBuilder()
-              .setCharacterMaskConfig(characterMaskConfig)
-              .build();
+          PrimitiveTransformation.newBuilder().setCharacterMaskConfig(characterMaskConfig).build();
 
       // Specify field to be de-identified.
       FieldId fieldId = FieldId.newBuilder().setName("HAPPINESS SCORE").build();
 
       // Specify when the above field should be de-identified.
-      Condition condition = Condition.newBuilder()
-          .setField(FieldId.newBuilder().setName("AGE").build())
-          .setOperator(RelationalOperator.GREATER_THAN)
-          .setValue(Value.newBuilder().setIntegerValue(89).build())
-          .build();
+      Condition condition =
+          Condition.newBuilder()
+              .setField(FieldId.newBuilder().setName("AGE").build())
+              .setOperator(RelationalOperator.GREATER_THAN)
+              .setValue(Value.newBuilder().setIntegerValue(89).build())
+              .build();
       // Apply the condition to records
-      RecordCondition recordCondition = RecordCondition.newBuilder()
-          .setExpressions(Expressions.newBuilder()
-              .setConditions(Conditions.newBuilder()
-                  .addConditions(condition)
-                  .build())
-              .build())
-          .build();
+      RecordCondition recordCondition =
+          RecordCondition.newBuilder()
+              .setExpressions(
+                  Expressions.newBuilder()
+                      .setConditions(Conditions.newBuilder().addConditions(condition).build())
+                      .build())
+              .build();
 
       // Associate the de-identification and conditions with the specified field.
       FieldTransformation fieldTransformation =
@@ -130,8 +131,7 @@ public class DeIdentifyTableConditionMasking {
       DeidentifyContentResponse response = dlp.deidentifyContent(request);
 
       // Print the results.
-      System.out.println(
-          "Table after de-identification: " + response.getItem().getTable());
+      System.out.println("Table after de-identification: " + response.getItem().getTable());
 
       return response.getItem().getTable();
     }

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableInfoTypes.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableInfoTypes.java
@@ -59,7 +59,7 @@ public class DeIdentifyTableInfoTypes {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "Charles Dickens name was a curse, possibly invented by Shakespeare.")
+                                "Charles Dickens name was a curse invented by Shakespeare.")
                             .build())
                     .build())
             .addRows(

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableInfoTypes.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableInfoTypes.java
@@ -45,32 +45,41 @@ public class DeIdentifyTableInfoTypes {
   public static void deIdentifyTableInfoTypes() throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "Charles Dickens name was a curse, possibly invented by Shakespeare.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "There are 14 kisses in Jane Austen's novels.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue(
+                                "Charles Dickens name was a curse, possibly invented by Shakespeare.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue("There are 14 kisses in Jane Austen's novels.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
+                    .build())
+            .build();
 
     deIdentifyTableInfoTypes(projectId, tableToDeIdentify);
   }
@@ -90,8 +99,10 @@ public class DeIdentifyTableInfoTypes {
       // Specify that findings should be replaced with corresponding info type name.
       ReplaceWithInfoTypeConfig replaceWithInfoTypeConfig =
           ReplaceWithInfoTypeConfig.getDefaultInstance();
-      PrimitiveTransformation primitiveTransformation = PrimitiveTransformation.newBuilder()
-          .setReplaceWithInfoTypeConfig(replaceWithInfoTypeConfig).build();
+      PrimitiveTransformation primitiveTransformation =
+          PrimitiveTransformation.newBuilder()
+              .setReplaceWithInfoTypeConfig(replaceWithInfoTypeConfig)
+              .build();
       // Associate info type with the replacement strategy
       InfoTypeTransformation infoTypeTransformation =
           InfoTypeTransformation.newBuilder()
@@ -99,14 +110,13 @@ public class DeIdentifyTableInfoTypes {
               .setPrimitiveTransformation(primitiveTransformation)
               .build();
       InfoTypeTransformations infoTypeTransformations =
-          InfoTypeTransformations.newBuilder()
-              .addTransformations(infoTypeTransformation)
-              .build();
+          InfoTypeTransformations.newBuilder().addTransformations(infoTypeTransformation).build();
 
       // Specify fields to be de-identified.
-      List<FieldId> fieldIds = Stream.of("PATIENT", "FACTOID")
-          .map(id -> FieldId.newBuilder().setName(id).build())
-          .collect(Collectors.toList());
+      List<FieldId> fieldIds =
+          Stream.of("PATIENT", "FACTOID")
+              .map(id -> FieldId.newBuilder().setName(id).build())
+              .collect(Collectors.toList());
 
       // Associate the de-identification and conditions with the specified field.
       FieldTransformation fieldTransformation =
@@ -132,8 +142,7 @@ public class DeIdentifyTableInfoTypes {
       DeidentifyContentResponse response = dlp.deidentifyContent(request);
 
       // Print the results.
-      System.out.println(
-          "Table after de-identification: " + response.getItem().getTable());
+      System.out.println("Table after de-identification: " + response.getItem().getTable());
 
       return response.getItem().getTable();
     }

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableRowSuppress.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableRowSuppress.java
@@ -42,26 +42,30 @@ public class DeIdentifyTableRowSuppress {
   public static void deIdentifyTableRowSuppress() throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .build())
+            .build();
 
     deIdentifyTableRowSuppress(projectId, tableToDeIdentify);
   }
@@ -76,24 +80,27 @@ public class DeIdentifyTableRowSuppress {
       ContentItem contentItem = ContentItem.newBuilder().setTable(tableToDeIdentify).build();
 
       // Specify when the content should be de-identified.
-      Condition condition = Condition.newBuilder()
-          .setField(FieldId.newBuilder().setName("AGE").build())
-          .setOperator(RelationalOperator.GREATER_THAN)
-          .setValue(Value.newBuilder().setIntegerValue(89).build()).build();
+      Condition condition =
+          Condition.newBuilder()
+              .setField(FieldId.newBuilder().setName("AGE").build())
+              .setOperator(RelationalOperator.GREATER_THAN)
+              .setValue(Value.newBuilder().setIntegerValue(89).build())
+              .build();
       // Apply the condition to record suppression.
       RecordSuppression recordSuppressions =
           RecordSuppression.newBuilder()
-              .setCondition(RecordCondition.newBuilder()
-                  .setExpressions(Expressions.newBuilder()
-                      .setConditions(Conditions.newBuilder().addConditions(condition).build())
+              .setCondition(
+                  RecordCondition.newBuilder()
+                      .setExpressions(
+                          Expressions.newBuilder()
+                              .setConditions(
+                                  Conditions.newBuilder().addConditions(condition).build())
+                              .build())
                       .build())
-                  .build())
               .build();
       // Use record suppression as the only transformation
       RecordTransformations transformations =
-          RecordTransformations.newBuilder()
-              .addRecordSuppressions(recordSuppressions)
-              .build();
+          RecordTransformations.newBuilder().addRecordSuppressions(recordSuppressions).build();
 
       DeidentifyConfig deidentifyConfig =
           DeidentifyConfig.newBuilder().setRecordTransformations(transformations).build();
@@ -110,8 +117,7 @@ public class DeIdentifyTableRowSuppress {
       DeidentifyContentResponse response = dlp.deidentifyContent(request);
 
       // Print the results.
-      System.out.println(
-          "Table after de-identification: " + response.getItem().getTable());
+      System.out.println("Table after de-identification: " + response.getItem().getTable());
 
       return response.getItem().getTable();
     }

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableWithFpe.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyTableWithFpe.java
@@ -29,10 +29,6 @@ import com.google.privacy.dlp.v2.DeidentifyContentRequest;
 import com.google.privacy.dlp.v2.DeidentifyContentResponse;
 import com.google.privacy.dlp.v2.FieldId;
 import com.google.privacy.dlp.v2.FieldTransformation;
-import com.google.privacy.dlp.v2.InfoType;
-import com.google.privacy.dlp.v2.InfoTypeTransformations;
-import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
-import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.KmsWrappedCryptoKey;
 import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
@@ -42,7 +38,6 @@ import com.google.privacy.dlp.v2.Table.Row;
 import com.google.privacy.dlp.v2.Value;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
-import java.util.Arrays;
 
 public class DeIdentifyTableWithFpe {
 
@@ -55,26 +50,30 @@ public class DeIdentifyTableWithFpe {
             + "keyRings/YOUR_KEYRING_NAME/"
             + "cryptoKeys/YOUR_KEY_NAME";
     String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
-        .addHeaders(FieldId.newBuilder().setName("Date").build())
-        .addHeaders(FieldId.newBuilder().setName("Compensation").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("11111").build())
-            .addValues(Value.newBuilder().setStringValue("2015").build())
-            .addValues(Value.newBuilder().setStringValue("$10").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("11111").build())
-            .addValues(Value.newBuilder().setStringValue("2016").build())
-            .addValues(Value.newBuilder().setStringValue("$20").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22222").build())
-            .addValues(Value.newBuilder().setStringValue("2016").build())
-            .addValues(Value.newBuilder().setStringValue("$15").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
+            .addHeaders(FieldId.newBuilder().setName("Date").build())
+            .addHeaders(FieldId.newBuilder().setName("Compensation").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("11111").build())
+                    .addValues(Value.newBuilder().setStringValue("2015").build())
+                    .addValues(Value.newBuilder().setStringValue("$10").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("11111").build())
+                    .addValues(Value.newBuilder().setStringValue("2016").build())
+                    .addValues(Value.newBuilder().setStringValue("$20").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22222").build())
+                    .addValues(Value.newBuilder().setStringValue("2016").build())
+                    .addValues(Value.newBuilder().setStringValue("$15").build())
+                    .build())
+            .build();
     deIdentifyTableWithFpe(projectId, tableToDeIdentify, kmsKeyName, wrappedAesKey);
   }
 

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyWithInfoType.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyWithInfoType.java
@@ -37,8 +37,7 @@ public class DeIdentifyWithInfoType {
   public static void main(String[] args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
-    String textToInspect =
-        "My email is test@example.com";
+    String textToInspect = "My email is test@example.com";
     deIdentifyWithInfoType(projectId, textToInspect);
   }
 
@@ -49,8 +48,7 @@ public class DeIdentifyWithInfoType {
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
       // Specify the content to be inspected.
-      ContentItem item = ContentItem.newBuilder()
-          .setValue(textToRedact).build();
+      ContentItem item = ContentItem.newBuilder().setValue(textToRedact).build();
 
       // Specify the type of info the inspection will look for.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
@@ -60,19 +58,22 @@ public class DeIdentifyWithInfoType {
       ReplaceWithInfoTypeConfig replaceWithInfoTypeConfig =
           ReplaceWithInfoTypeConfig.newBuilder().build();
       // Define type of deidentification as replacement with info type.
-      PrimitiveTransformation primitiveTransformation = PrimitiveTransformation.newBuilder()
-          .setReplaceWithInfoTypeConfig(replaceWithInfoTypeConfig)
-          .build();
+      PrimitiveTransformation primitiveTransformation =
+          PrimitiveTransformation.newBuilder()
+              .setReplaceWithInfoTypeConfig(replaceWithInfoTypeConfig)
+              .build();
       // Associate deidentification type with info type.
-      InfoTypeTransformation transformation = InfoTypeTransformation.newBuilder()
-          .addInfoTypes(infoType)
-          .setPrimitiveTransformation(primitiveTransformation)
-          .build();
+      InfoTypeTransformation transformation =
+          InfoTypeTransformation.newBuilder()
+              .addInfoTypes(infoType)
+              .setPrimitiveTransformation(primitiveTransformation)
+              .build();
       // Construct the configuration for the Redact request and list all desired transformations.
-      DeidentifyConfig redactConfig = DeidentifyConfig.newBuilder()
-          .setInfoTypeTransformations(InfoTypeTransformations.newBuilder()
-              .addTransformations(transformation))
-          .build();
+      DeidentifyConfig redactConfig =
+          DeidentifyConfig.newBuilder()
+              .setInfoTypeTransformations(
+                  InfoTypeTransformations.newBuilder().addTransformations(transformation))
+              .build();
 
       // Construct the Redact request to be sent by the client.
       DeidentifyContentRequest request =

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyWithRedaction.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyWithRedaction.java
@@ -48,27 +48,29 @@ public class DeIdentifyWithRedaction {
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
       // Specify the content to be inspected.
-      ContentItem item = ContentItem.newBuilder()
-          .setValue(textToRedact).build();
+      ContentItem item = ContentItem.newBuilder().setValue(textToRedact).build();
 
       // Specify the type of info the inspection will look for.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
       InfoType infoType = InfoType.newBuilder().setName("EMAIL_ADDRESS").build();
       InspectConfig inspectConfig = InspectConfig.newBuilder().addInfoTypes(infoType).build();
       // Define type of deidentification.
-      PrimitiveTransformation primitiveTransformation = PrimitiveTransformation.newBuilder()
-          .setRedactConfig(RedactConfig.getDefaultInstance())
-          .build();
+      PrimitiveTransformation primitiveTransformation =
+          PrimitiveTransformation.newBuilder()
+              .setRedactConfig(RedactConfig.getDefaultInstance())
+              .build();
       // Associate deidentification type with info type.
-      InfoTypeTransformation transformation = InfoTypeTransformation.newBuilder()
-          .addInfoTypes(infoType)
-          .setPrimitiveTransformation(primitiveTransformation)
-          .build();
+      InfoTypeTransformation transformation =
+          InfoTypeTransformation.newBuilder()
+              .addInfoTypes(infoType)
+              .setPrimitiveTransformation(primitiveTransformation)
+              .build();
       // Construct the configuration for the Redact request and list all desired transformations.
-      DeidentifyConfig redactConfig = DeidentifyConfig.newBuilder()
-          .setInfoTypeTransformations(InfoTypeTransformations.newBuilder()
-              .addTransformations(transformation))
-          .build();
+      DeidentifyConfig redactConfig =
+          DeidentifyConfig.newBuilder()
+              .setInfoTypeTransformations(
+                  InfoTypeTransformations.newBuilder().addTransformations(transformation))
+              .build();
 
       // Construct the Redact request to be sent by the client.
       DeidentifyContentRequest request =

--- a/samples/snippets/src/main/java/dlp/snippets/DeIdentifyWithReplacement.java
+++ b/samples/snippets/src/main/java/dlp/snippets/DeIdentifyWithReplacement.java
@@ -29,7 +29,6 @@ import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
-import com.google.privacy.dlp.v2.RedactConfig;
 import com.google.privacy.dlp.v2.ReplaceValueConfig;
 import com.google.privacy.dlp.v2.Value;
 
@@ -50,31 +49,32 @@ public class DeIdentifyWithReplacement {
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
       // Specify the content to be inspected.
-      ContentItem item = ContentItem.newBuilder()
-          .setValue(textToRedact).build();
+      ContentItem item = ContentItem.newBuilder().setValue(textToRedact).build();
 
       // Specify the type of info the inspection will look for.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
       InfoType infoType = InfoType.newBuilder().setName("EMAIL_ADDRESS").build();
       InspectConfig inspectConfig = InspectConfig.newBuilder().addInfoTypes(infoType).build();
       // Specify replacement string to be used for the finding.
-      ReplaceValueConfig replaceValueConfig = ReplaceValueConfig.newBuilder()
-          .setNewValue(Value.newBuilder().setStringValue("[email-address]").build())
-          .build();
+      ReplaceValueConfig replaceValueConfig =
+          ReplaceValueConfig.newBuilder()
+              .setNewValue(Value.newBuilder().setStringValue("[email-address]").build())
+              .build();
       // Define type of deidentification as replacement.
-      PrimitiveTransformation primitiveTransformation = PrimitiveTransformation.newBuilder()
-          .setReplaceConfig(replaceValueConfig)
-          .build();
+      PrimitiveTransformation primitiveTransformation =
+          PrimitiveTransformation.newBuilder().setReplaceConfig(replaceValueConfig).build();
       // Associate deidentification type with info type.
-      InfoTypeTransformation transformation = InfoTypeTransformation.newBuilder()
-          .addInfoTypes(infoType)
-          .setPrimitiveTransformation(primitiveTransformation)
-          .build();
+      InfoTypeTransformation transformation =
+          InfoTypeTransformation.newBuilder()
+              .addInfoTypes(infoType)
+              .setPrimitiveTransformation(primitiveTransformation)
+              .build();
       // Construct the configuration for the Redact request and list all desired transformations.
-      DeidentifyConfig redactConfig = DeidentifyConfig.newBuilder()
-          .setInfoTypeTransformations(InfoTypeTransformations.newBuilder()
-              .addTransformations(transformation))
-          .build();
+      DeidentifyConfig redactConfig =
+          DeidentifyConfig.newBuilder()
+              .setInfoTypeTransformations(
+                  InfoTypeTransformations.newBuilder().addTransformations(transformation))
+              .build();
 
       // Construct the Redact request to be sent by the client.
       DeidentifyContentRequest request =

--- a/samples/snippets/src/main/java/dlp/snippets/InspectBigQueryTable.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectBigQueryTable.java
@@ -93,10 +93,7 @@ public class InspectBigQueryTable {
 
       // Specify how the content should be inspected.
       InspectConfig inspectConfig =
-          InspectConfig.newBuilder()
-              .addAllInfoTypes(infoTypes)
-              .setIncludeQuote(true)
-              .build();
+          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
 
       // Specify the action that is triggered when the job completes.
       String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);

--- a/samples/snippets/src/main/java/dlp/snippets/InspectBigQueryTableWithSampling.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectBigQueryTableWithSampling.java
@@ -88,10 +88,7 @@ public class InspectBigQueryTableWithSampling {
 
       // Specify how the content should be inspected.
       InspectConfig inspectConfig =
-          InspectConfig.newBuilder()
-              .addInfoTypes(infoType)
-              .setIncludeQuote(true)
-              .build();
+          InspectConfig.newBuilder().addInfoTypes(infoType).setIncludeQuote(true).build();
 
       // Specify the action that is triggered when the job completes.
       String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);

--- a/samples/snippets/src/main/java/dlp/snippets/InspectDatastoreEntity.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectDatastoreEntity.java
@@ -94,10 +94,7 @@ public class InspectDatastoreEntity {
 
       // Specify how the content should be inspected.
       InspectConfig inspectConfig =
-          InspectConfig.newBuilder()
-              .addAllInfoTypes(infoTypes)
-              .setIncludeQuote(true)
-              .build();
+          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
 
       // Specify the action that is triggered when the job completes.
       String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);

--- a/samples/snippets/src/main/java/dlp/snippets/InspectGcsFile.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectGcsFile.java
@@ -67,9 +67,7 @@ public class InspectGcsFile {
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
       // Specify the GCS file to be inspected.
       CloudStorageOptions cloudStorageOptions =
-          CloudStorageOptions.newBuilder()
-              .setFileSet(FileSet.newBuilder().setUrl(gcsUri))
-              .build();
+          CloudStorageOptions.newBuilder().setFileSet(FileSet.newBuilder().setUrl(gcsUri)).build();
 
       StorageConfig storageConfig =
           StorageConfig.newBuilder().setCloudStorageOptions(cloudStorageOptions).build();
@@ -83,10 +81,7 @@ public class InspectGcsFile {
 
       // Specify how the content should be inspected.
       InspectConfig inspectConfig =
-          InspectConfig.newBuilder()
-              .addAllInfoTypes(infoTypes)
-              .setIncludeQuote(true)
-              .build();
+          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
 
       // Specify the action that is triggered when the job completes.
       String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);

--- a/samples/snippets/src/main/java/dlp/snippets/InspectImageFile.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectImageFile.java
@@ -58,16 +58,13 @@ public class InspectImageFile {
       // Specify the type of info the inspection will look for.
       List<InfoType> infoTypes = new ArrayList<>();
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
-      for (String typeName : new String[]{"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
+      for (String typeName : new String[] {"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =
-          InspectConfig.newBuilder()
-              .addAllInfoTypes(infoTypes)
-              .setIncludeQuote(true)
-              .build();
+          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
 
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =

--- a/samples/snippets/src/main/java/dlp/snippets/InspectImageFileAllInfoTypes.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectImageFileAllInfoTypes.java
@@ -39,8 +39,7 @@ class InspectImageFileAllInfoTypes {
     inspectImageFileAllInfoTypes(projectId, inputPath);
   }
 
-  static void inspectImageFileAllInfoTypes(String projectId, String inputPath)
-      throws IOException {
+  static void inspectImageFileAllInfoTypes(String projectId, String inputPath) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.

--- a/samples/snippets/src/main/java/dlp/snippets/InspectImageFileListedInfoTypes.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectImageFileListedInfoTypes.java
@@ -63,10 +63,7 @@ class InspectImageFileListedInfoTypes {
       }
 
       // Construct the configuration for the Inspect request.
-      InspectConfig inspectConfig =
-          InspectConfig.newBuilder()
-              .addAllInfoTypes(infoTypes)
-              .build();
+      InspectConfig inspectConfig = InspectConfig.newBuilder().addAllInfoTypes(infoTypes).build();
 
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =

--- a/samples/snippets/src/main/java/dlp/snippets/InspectPhoneNumber.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectPhoneNumber.java
@@ -45,9 +45,7 @@ public class InspectPhoneNumber {
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
       // Specify the type and content to be inspected.
-      ContentItem item = ContentItem.newBuilder()
-          .setValue(textToInspect)
-          .build();
+      ContentItem item = ContentItem.newBuilder().setValue(textToInspect).build();
 
       // Specify the type of info the inspection will look for.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types

--- a/samples/snippets/src/main/java/dlp/snippets/InspectString.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectString.java
@@ -65,10 +65,7 @@ public class InspectString {
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =
-          InspectConfig.newBuilder()
-              .addAllInfoTypes(infoTypes)
-              .setIncludeQuote(true)
-              .build();
+          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
 
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =

--- a/samples/snippets/src/main/java/dlp/snippets/InspectStringCustomExcludingSubstring.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectStringCustomExcludingSubstring.java
@@ -49,13 +49,17 @@ public class InspectStringCustomExcludingSubstring {
     String textToInspect = "Name: Doe, John. Name: Example, Jimmy";
     String customDetectorPattern = "[A-Z][a-z]{1,15}, [A-Z][a-z]{1,15}";
     List<String> excludedSubstringList = Arrays.asList("Jimmy");
-    inspectStringCustomExcludingSubstring(projectId, textToInspect, customDetectorPattern,
-        excludedSubstringList);
+    inspectStringCustomExcludingSubstring(
+        projectId, textToInspect, customDetectorPattern, excludedSubstringList);
   }
 
   // Inspects the provided text, avoiding matches specified in the exclusion list.
-  public static void inspectStringCustomExcludingSubstring(String projectId, String textToInspect,
-      String customDetectorPattern, List<String> excludedSubstringList) throws IOException {
+  public static void inspectStringCustomExcludingSubstring(
+      String projectId,
+      String textToInspect,
+      String customDetectorPattern,
+      List<String> excludedSubstringList)
+      throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
@@ -72,15 +76,17 @@ public class InspectStringCustomExcludingSubstring {
       InfoType infoType = InfoType.newBuilder().setName("CUSTOM_NAME_DETECTOR").build();
       CustomInfoType customInfoType =
           CustomInfoType.newBuilder()
-              .setInfoType(infoType).setRegex(Regex.newBuilder().setPattern(customDetectorPattern))
+              .setInfoType(infoType)
+              .setRegex(Regex.newBuilder().setPattern(customDetectorPattern))
               .build();
 
       // Exclude partial matches from the specified excludedSubstringList.
       ExclusionRule exclusionRule =
           ExclusionRule.newBuilder()
               .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
-              .setDictionary(Dictionary.newBuilder()
-                  .setWordList(WordList.newBuilder().addAllWords(excludedSubstringList)))
+              .setDictionary(
+                  Dictionary.newBuilder()
+                      .setWordList(WordList.newBuilder().addAllWords(excludedSubstringList)))
               .build();
 
       // Construct a ruleset that applies the exclusion rule to the EMAIL_ADDRESSES infotype.

--- a/samples/snippets/src/main/java/dlp/snippets/InspectStringCustomHotword.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectStringCustomHotword.java
@@ -49,8 +49,8 @@ public class InspectStringCustomHotword {
   }
 
   // Inspects the provided text.
-  public static void inspectStringCustomHotword(String projectId, String textToInspect,
-      String customHotword) throws IOException {
+  public static void inspectStringCustomHotword(
+      String projectId, String textToInspect, String customHotword) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.

--- a/samples/snippets/src/main/java/dlp/snippets/InspectStringOmitOverlap.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectStringOmitOverlap.java
@@ -65,15 +65,16 @@ public class InspectStringOmitOverlap {
       // Specify the type of info the inspection will look for.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types.
       List<InfoType> infoTypes = new ArrayList<>();
-      for (String typeName : new String[]{"PERSON_NAME", "EMAIL_ADDRESS"}) {
+      for (String typeName : new String[] {"PERSON_NAME", "EMAIL_ADDRESS"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
 
       // Exclude EMAIL_ADDRESS matches
       ExclusionRule exclusionRule =
           ExclusionRule.newBuilder()
-              .setExcludeInfoTypes(ExcludeInfoTypes.newBuilder()
-                  .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS")))
+              .setExcludeInfoTypes(
+                  ExcludeInfoTypes.newBuilder()
+                      .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS")))
               .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
               .build();
 

--- a/samples/snippets/src/main/java/dlp/snippets/InspectStringWithExclusionDict.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectStringWithExclusionDict.java
@@ -51,8 +51,8 @@ public class InspectStringWithExclusionDict {
   }
 
   // Inspects the provided text, avoiding matches specified in the exclusion list.
-  public static void inspectStringWithExclusionDict(String projectId, String textToInspect,
-      List<String> excludedMatchList) throws IOException {
+  public static void inspectStringWithExclusionDict(
+      String projectId, String textToInspect, List<String> excludedMatchList) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
@@ -68,7 +68,7 @@ public class InspectStringWithExclusionDict {
       // Specify the type of info the inspection will look for.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types.
       List<InfoType> infoTypes = new ArrayList<>();
-      for (String typeName : new String[]{"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
+      for (String typeName : new String[] {"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
 
@@ -76,8 +76,9 @@ public class InspectStringWithExclusionDict {
       ExclusionRule exclusionRule =
           ExclusionRule.newBuilder()
               .setMatchingType(MatchingType.MATCHING_TYPE_FULL_MATCH)
-              .setDictionary(Dictionary.newBuilder()
-                  .setWordList(WordList.newBuilder().addAllWords(excludedMatchList)))
+              .setDictionary(
+                  Dictionary.newBuilder()
+                      .setWordList(WordList.newBuilder().addAllWords(excludedMatchList)))
               .build();
 
       // Construct a ruleset that applies the exclusion rule to the EMAIL_ADDRESSES infotype.

--- a/samples/snippets/src/main/java/dlp/snippets/InspectStringWithExclusionDictSubstring.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectStringWithExclusionDictSubstring.java
@@ -51,8 +51,9 @@ public class InspectStringWithExclusionDictSubstring {
   }
 
   // Inspects the provided text, avoiding matches specified in the exclusion list.
-  public static void inspectStringWithExclusionDictSubstring(String projectId, String textToInspect,
-      List<String> excludedSubstringList) throws IOException {
+  public static void inspectStringWithExclusionDictSubstring(
+      String projectId, String textToInspect, List<String> excludedSubstringList)
+      throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
@@ -68,8 +69,8 @@ public class InspectStringWithExclusionDictSubstring {
       // Specify the type of info the inspection will look for.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types.
       List<InfoType> infoTypes = new ArrayList<>();
-      for (String typeName : new String[]{"EMAIL_ADDRESS", "DOMAIN_NAME", "PHONE_NUMBER",
-          "PERSON_NAME"}) {
+      for (String typeName :
+          new String[] {"EMAIL_ADDRESS", "DOMAIN_NAME", "PHONE_NUMBER", "PERSON_NAME"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
 
@@ -77,8 +78,9 @@ public class InspectStringWithExclusionDictSubstring {
       ExclusionRule exclusionRule =
           ExclusionRule.newBuilder()
               .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
-              .setDictionary(Dictionary.newBuilder()
-                  .setWordList(WordList.newBuilder().addAllWords(excludedSubstringList)))
+              .setDictionary(
+                  Dictionary.newBuilder()
+                      .setWordList(WordList.newBuilder().addAllWords(excludedSubstringList)))
               .build();
 
       // Construct a ruleset that applies the exclusion rule to the EMAIL_ADDRESSES infotype.

--- a/samples/snippets/src/main/java/dlp/snippets/InspectStringWithExclusionRegex.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectStringWithExclusionRegex.java
@@ -49,8 +49,8 @@ public class InspectStringWithExclusionRegex {
   }
 
   // Inspects the provided text, avoiding matches specified in the exclusion list.
-  public static void inspectStringWithExclusionRegex(String projectId, String textToInspect,
-      String excludedRegex) throws IOException {
+  public static void inspectStringWithExclusionRegex(
+      String projectId, String textToInspect, String excludedRegex) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
@@ -66,7 +66,7 @@ public class InspectStringWithExclusionRegex {
       // Specify the type of info the inspection will look for.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types.
       List<InfoType> infoTypes = new ArrayList<>();
-      for (String typeName : new String[]{"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
+      for (String typeName : new String[] {"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
 

--- a/samples/snippets/src/main/java/dlp/snippets/InspectStringWithoutOverlap.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectStringWithoutOverlap.java
@@ -67,7 +67,7 @@ public class InspectStringWithoutOverlap {
       // Specify the type of info the inspection will look for.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types.
       List<InfoType> infoTypes = new ArrayList<>();
-      for (String typeName : new String[]{"DOMAIN_NAME", "EMAIL_ADDRESS"}) {
+      for (String typeName : new String[] {"DOMAIN_NAME", "EMAIL_ADDRESS"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
 
@@ -81,8 +81,9 @@ public class InspectStringWithoutOverlap {
       // Exclude EMAIL_ADDRESS matches
       ExclusionRule exclusionRule =
           ExclusionRule.newBuilder()
-              .setExcludeInfoTypes(ExcludeInfoTypes.newBuilder()
-                  .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS")))
+              .setExcludeInfoTypes(
+                  ExcludeInfoTypes.newBuilder()
+                      .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS")))
               .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
               .build();
 

--- a/samples/snippets/src/main/java/dlp/snippets/InspectTable.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectTable.java
@@ -19,8 +19,6 @@ package dlp.snippets;
 // [START dlp_inspect_table]
 
 import com.google.cloud.dlp.v2.DlpServiceClient;
-import com.google.privacy.dlp.v2.ByteContentItem;
-import com.google.privacy.dlp.v2.ByteContentItem.BytesType;
 import com.google.privacy.dlp.v2.ContentItem;
 import com.google.privacy.dlp.v2.FieldId;
 import com.google.privacy.dlp.v2.Finding;
@@ -28,28 +26,25 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectContentRequest;
 import com.google.privacy.dlp.v2.InspectContentResponse;
-import com.google.privacy.dlp.v2.Likelihood;
 import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.Table;
 import com.google.privacy.dlp.v2.Table.Row;
 import com.google.privacy.dlp.v2.Value;
-import com.google.protobuf.ByteString;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class InspectTable {
 
   public static void main(String[] args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
-    Table tableToInspect = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("name").build())
-        .addHeaders(FieldId.newBuilder().setName("phone").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("John Doe").build())
-            .addValues(Value.newBuilder().setStringValue("(206) 555-0123").build()))
-        .build();
+    Table tableToInspect =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("name").build())
+            .addHeaders(FieldId.newBuilder().setName("phone").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("John Doe").build())
+                    .addValues(Value.newBuilder().setStringValue("(206) 555-0123").build()))
+            .build();
 
     inspectTable(projectId, tableToInspect);
   }
@@ -69,10 +64,7 @@ public class InspectTable {
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =
-          InspectConfig.newBuilder()
-              .addInfoTypes(infoType)
-              .setIncludeQuote(true)
-              .build();
+          InspectConfig.newBuilder().addInfoTypes(infoType).setIncludeQuote(true).build();
 
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =

--- a/samples/snippets/src/main/java/dlp/snippets/InspectTextFile.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectTextFile.java
@@ -58,16 +58,13 @@ public class InspectTextFile {
       // Specify the type of info the inspection will look for.
       List<InfoType> infoTypes = new ArrayList<>();
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
-      for (String typeName : new String[]{"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
+      for (String typeName : new String[] {"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =
-          InspectConfig.newBuilder()
-              .addAllInfoTypes(infoTypes)
-              .setIncludeQuote(true)
-              .build();
+          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
 
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =

--- a/samples/snippets/src/main/java/dlp/snippets/InspectWithCustomRegex.java
+++ b/samples/snippets/src/main/java/dlp/snippets/InspectWithCustomRegex.java
@@ -65,10 +65,7 @@ public class InspectWithCustomRegex {
       // Construct the custom regex detector.
       InfoType infoType = InfoType.newBuilder().setName("C_MRN").build();
       CustomInfoType customInfoType =
-          CustomInfoType.newBuilder()
-              .setInfoType(infoType)
-              .setRegex(regex)
-              .build();
+          CustomInfoType.newBuilder().setInfoType(infoType).setRegex(regex).build();
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =
@@ -81,7 +78,8 @@ public class InspectWithCustomRegex {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(LocationName.of(projectId, "global").toString()).setItem(item)
+              .setParent(LocationName.of(projectId, "global").toString())
+              .setItem(item)
               .setInspectConfig(config)
               .build();
 

--- a/samples/snippets/src/main/java/dlp/snippets/ReIdentifyTableWithFpe.java
+++ b/samples/snippets/src/main/java/dlp/snippets/ReIdentifyTableWithFpe.java
@@ -24,15 +24,9 @@ import com.google.privacy.dlp.v2.ContentItem;
 import com.google.privacy.dlp.v2.CryptoKey;
 import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig;
 import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig.FfxCommonNativeAlphabet;
-import com.google.privacy.dlp.v2.CustomInfoType;
-import com.google.privacy.dlp.v2.CustomInfoType.SurrogateType;
 import com.google.privacy.dlp.v2.DeidentifyConfig;
 import com.google.privacy.dlp.v2.FieldId;
 import com.google.privacy.dlp.v2.FieldTransformation;
-import com.google.privacy.dlp.v2.InfoType;
-import com.google.privacy.dlp.v2.InfoTypeTransformations;
-import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
-import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.KmsWrappedCryptoKey;
 import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
@@ -56,13 +50,14 @@ public class ReIdentifyTableWithFpe {
             + "keyRings/YOUR_KEYRING_NAME/"
             + "cryptoKeys/YOUR_KEY_NAME";
     String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
-    Table tableToReIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
-        .addRows(
-            Row.newBuilder().addValues(
-                Value.newBuilder().setStringValue("28777").build())
-                .build())
-        .build();
+    Table tableToReIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("28777").build())
+                    .build())
+            .build();
     reIdentifyTableWithFpe(projectId, tableToReIdentify, kmsKeyName, wrappedAesKey);
   }
 

--- a/samples/snippets/src/main/java/dlp/snippets/RedactImageFile.java
+++ b/samples/snippets/src/main/java/dlp/snippets/RedactImageFile.java
@@ -83,7 +83,6 @@ class RedactImageFile {
       redacted.write(response.getRedactedImage().toByteArray());
       redacted.close();
       System.out.println("Redacted image written to " + outputPath);
-
     }
   }
 }

--- a/samples/snippets/src/main/java/dlp/snippets/RedactImageFileColoredInfoTypes.java
+++ b/samples/snippets/src/main/java/dlp/snippets/RedactImageFileColoredInfoTypes.java
@@ -59,18 +59,21 @@ class RedactImageFileColoredInfoTypes {
 
       // Define types of info to redact associate each one with a different color.
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
-      ImageRedactionConfig ssnRedactionConfig = ImageRedactionConfig.newBuilder()
-          .setInfoType(InfoType.newBuilder().setName("US_SOCIAL_SECURITY_NUMBER").build())
-          .setRedactionColor(Color.newBuilder().setRed(.3f).setGreen(.1f).setBlue(.6f).build())
-          .build();
-      ImageRedactionConfig emailRedactionConfig = ImageRedactionConfig.newBuilder()
-          .setInfoType(InfoType.newBuilder().setName("EMAIL_ADDRESS").build())
-          .setRedactionColor(Color.newBuilder().setRed(.5f).setGreen(.5f).setBlue(1).build())
-          .build();
-      ImageRedactionConfig phoneRedactionConfig = ImageRedactionConfig.newBuilder()
-          .setInfoType(InfoType.newBuilder().setName("PHONE_NUMBER").build())
-          .setRedactionColor(Color.newBuilder().setRed(1).setGreen(0).setBlue(.6f).build())
-          .build();
+      ImageRedactionConfig ssnRedactionConfig =
+          ImageRedactionConfig.newBuilder()
+              .setInfoType(InfoType.newBuilder().setName("US_SOCIAL_SECURITY_NUMBER").build())
+              .setRedactionColor(Color.newBuilder().setRed(.3f).setGreen(.1f).setBlue(.6f).build())
+              .build();
+      ImageRedactionConfig emailRedactionConfig =
+          ImageRedactionConfig.newBuilder()
+              .setInfoType(InfoType.newBuilder().setName("EMAIL_ADDRESS").build())
+              .setRedactionColor(Color.newBuilder().setRed(.5f).setGreen(.5f).setBlue(1).build())
+              .build();
+      ImageRedactionConfig phoneRedactionConfig =
+          ImageRedactionConfig.newBuilder()
+              .setInfoType(InfoType.newBuilder().setName("PHONE_NUMBER").build())
+              .setRedactionColor(Color.newBuilder().setRed(1).setGreen(0).setBlue(.6f).build())
+              .build();
 
       // Create collection of all redact configurations.
       List<ImageRedactionConfig> imageRedactionConfigs =
@@ -79,9 +82,10 @@ class RedactImageFileColoredInfoTypes {
       // List types of info to search for.
       InspectConfig config =
           InspectConfig.newBuilder()
-              .addAllInfoTypes(imageRedactionConfigs.stream()
-                  .map(ImageRedactionConfig::getInfoType)
-                  .collect(Collectors.toList()))
+              .addAllInfoTypes(
+                  imageRedactionConfigs.stream()
+                      .map(ImageRedactionConfig::getInfoType)
+                      .collect(Collectors.toList()))
               .build();
 
       // Construct the Redact request to be sent by the client.
@@ -101,7 +105,6 @@ class RedactImageFileColoredInfoTypes {
       redacted.write(response.getRedactedImage().toByteArray());
       redacted.close();
       System.out.println("Redacted image written to " + outputPath);
-
     }
   }
 }

--- a/samples/snippets/src/main/java/dlp/snippets/RedactImageFileListedInfoTypes.java
+++ b/samples/snippets/src/main/java/dlp/snippets/RedactImageFileListedInfoTypes.java
@@ -63,15 +63,13 @@ class RedactImageFileListedInfoTypes {
           new String[] {"US_SOCIAL_SECURITY_NUMBER", "EMAIL_ADDRESS", "PHONE_NUMBER"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
-      InspectConfig inspectConfig =
-          InspectConfig.newBuilder()
-              .addAllInfoTypes(infoTypes)
-              .build();
+      InspectConfig inspectConfig = InspectConfig.newBuilder().addAllInfoTypes(infoTypes).build();
 
       // Prepare redaction configs.
-      List<ImageRedactionConfig> imageRedactionConfigs = infoTypes.stream()
-          .map(infoType -> ImageRedactionConfig.newBuilder().setInfoType(infoType).build())
-          .collect(Collectors.toList());
+      List<ImageRedactionConfig> imageRedactionConfigs =
+          infoTypes.stream()
+              .map(infoType -> ImageRedactionConfig.newBuilder().setInfoType(infoType).build())
+              .collect(Collectors.toList());
 
       // Construct the Redact request to be sent by the client.
       RedactImageRequest request =
@@ -90,7 +88,6 @@ class RedactImageFileListedInfoTypes {
       redacted.write(response.getRedactedImage().toByteArray());
       redacted.close();
       System.out.println("Redacted image written to " + outputPath);
-
     }
   }
 }

--- a/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
+++ b/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
@@ -20,6 +20,7 @@ package dlp.snippets;
 
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.cloud.dlp.v2.DlpServiceSettings;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
@@ -49,6 +50,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import org.threeten.bp.Duration;
 
 class RiskAnalysisLDiversity {
 
@@ -69,7 +71,18 @@ class RiskAnalysisLDiversity {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (DlpServiceClient dlpServiceClient = DlpServiceClient.create()) {
+    DlpServiceSettings.Builder dlpServiceSettingsBuilder = DlpServiceSettings.newBuilder();
+    dlpServiceSettingsBuilder
+        .getDlpJobSettings()
+        .setRetrySettings(
+            dlpServiceSettingsBuilder
+                .getDlpJobSettings()
+                .getRetrySettings()
+                .toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(600))
+                .build());
+    try (DlpServiceClient dlpServiceClient =
+        DlpServiceClient.create(dlpServiceSettingsBuilder.build())) {
       // Specify the BigQuery table to analyze
       BigQueryTable bigQueryTable =
           BigQueryTable.newBuilder()

--- a/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
@@ -276,7 +276,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "Charles Dickens name was a curse, possibly invented by Shakespeare.")
+                                "Charles Dickens name was a curse invented by Shakespeare.")
                             .build())
                     .build())
             .addRows(
@@ -412,7 +412,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "Charles Dickens name was a curse, possibly invented by Shakespeare.")
+                                "Charles Dickens name was a curse invented by Shakespeare.")
                             .build())
                     .build())
             .addRows(
@@ -447,7 +447,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "[PERSON_NAME] name was a curse, possibly invented by Shakespeare.")
+                                "[PERSON_NAME] name was a curse invented by Shakespeare.")
                             .build())
                     .build())
             .addRows(

--- a/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
@@ -37,9 +37,11 @@ public class DeIdentificationTests extends TestBase {
 
   @Override
   protected ImmutableList<String> requiredEnvVars() {
-    return ImmutableList
-        .of("GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "DLP_DEID_WRAPPED_KEY",
-            "DLP_DEID_KEY_NAME");
+    return ImmutableList.of(
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "DLP_DEID_WRAPPED_KEY",
+        "DLP_DEID_KEY_NAME");
   }
 
   @Test
@@ -79,10 +81,7 @@ public class DeIdentificationTests extends TestBase {
   @Test
   public void testReIdentifyTextWithFpe() throws IOException {
     ReIdentifyTextWithFpe.reIdentifyTextWithFpe(
-        PROJECT_ID,
-        "My phone number is PHONE_TOKEN(10):9617256398",
-        kmsKeyName,
-        wrappedKey);
+        PROJECT_ID, "My phone number is PHONE_TOKEN(10):9617256398", kmsKeyName, wrappedKey);
 
     String output = bout.toString();
     assertThat(output).contains("Text after re-identification: ");
@@ -90,26 +89,30 @@ public class DeIdentificationTests extends TestBase {
 
   @Test
   public void testDeIdentifyTableWithFpe() throws IOException {
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
-        .addHeaders(FieldId.newBuilder().setName("Date").build())
-        .addHeaders(FieldId.newBuilder().setName("Compensation").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("11111").build())
-            .addValues(Value.newBuilder().setStringValue("2015").build())
-            .addValues(Value.newBuilder().setStringValue("$10").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("11111").build())
-            .addValues(Value.newBuilder().setStringValue("2016").build())
-            .addValues(Value.newBuilder().setStringValue("$20").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22222").build())
-            .addValues(Value.newBuilder().setStringValue("2016").build())
-            .addValues(Value.newBuilder().setStringValue("$15").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
+            .addHeaders(FieldId.newBuilder().setName("Date").build())
+            .addHeaders(FieldId.newBuilder().setName("Compensation").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("11111").build())
+                    .addValues(Value.newBuilder().setStringValue("2015").build())
+                    .addValues(Value.newBuilder().setStringValue("$10").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("11111").build())
+                    .addValues(Value.newBuilder().setStringValue("2016").build())
+                    .addValues(Value.newBuilder().setStringValue("$20").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22222").build())
+                    .addValues(Value.newBuilder().setStringValue("2016").build())
+                    .addValues(Value.newBuilder().setStringValue("$15").build())
+                    .build())
+            .build();
 
     DeIdentifyTableWithFpe.deIdentifyTableWithFpe(
         PROJECT_ID, tableToDeIdentify, kmsKeyName, wrappedKey);
@@ -120,11 +123,14 @@ public class DeIdentificationTests extends TestBase {
 
   @Test
   public void testReIdentifyTableWithFpe() throws IOException {
-    Table tableToReIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("28777").build()).build())
-        .build();
+    Table tableToReIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("28777").build())
+                    .build())
+            .build();
 
     ReIdentifyTableWithFpe.reIdentifyTableWithFpe(
         PROJECT_ID, tableToReIdentify, kmsKeyName, wrappedKey);
@@ -136,46 +142,54 @@ public class DeIdentificationTests extends TestBase {
   @Test
   public void testDeIdentifyTableBucketing() throws IOException {
     // Transform a column based on the value of another column
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .build())
-        .build();
-    Table expectedTable = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("90:100").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("20:30").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("70:80").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .build())
+            .build();
+    Table expectedTable =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("90:100").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("20:30").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("70:80").build())
+                    .build())
+            .build();
 
     Table table = DeIdentifyTableBucketing.deIdentifyTableBucketing(PROJECT_ID, tableToDeIdentify);
 
@@ -187,49 +201,58 @@ public class DeIdentificationTests extends TestBase {
   @Test
   public void testDeIdentifyTableConditionMasking() throws IOException {
     // Transform a column based on the value of another column
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .build())
-        .build();
-    Table expectedTable = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("**").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .build())
+            .build();
+    Table expectedTable =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("**").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .build())
+            .build();
 
-    Table table = DeIdentifyTableConditionMasking.deIdentifyTableConditionMasking(
-        PROJECT_ID, tableToDeIdentify);
+    Table table =
+        DeIdentifyTableConditionMasking.deIdentifyTableConditionMasking(
+            PROJECT_ID, tableToDeIdentify);
 
     String output = bout.toString();
     assertThat(output).contains("Table after de-identification:");
@@ -239,58 +262,77 @@ public class DeIdentificationTests extends TestBase {
   @Test
   public void testDeIdentifyTableInfoTypes() throws IOException {
     // Transform findings found in column
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "Charles Dickens name was a curse, possibly invented by Shakespeare.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "There are 14 kisses in Jane Austen's novels.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
-            .build())
-        .build();
-    Table expectedTable = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("[PERSON_NAME]").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "[PERSON_NAME] name was a curse, possibly invented by Shakespeare.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("[PERSON_NAME]").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "There are 14 kisses in [PERSON_NAME] novels.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("[PERSON_NAME]").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .addValues(Value.newBuilder().setStringValue("[PERSON_NAME] loved cats.").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue(
+                                "Charles Dickens name was a curse, possibly invented by Shakespeare.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue("There are 14 kisses in Jane Austen's novels.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
+                    .build())
+            .build();
+    Table expectedTable =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("[PERSON_NAME]").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue(
+                                "[PERSON_NAME] name was a curse, possibly invented by Shakespeare.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("[PERSON_NAME]").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue("There are 14 kisses in [PERSON_NAME] novels.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("[PERSON_NAME]").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .addValues(
+                        Value.newBuilder().setStringValue("[PERSON_NAME] loved cats.").build())
+                    .build())
+            .build();
 
     Table table = DeIdentifyTableInfoTypes.deIdentifyTableInfoTypes(PROJECT_ID, tableToDeIdentify);
 
@@ -302,44 +344,51 @@ public class DeIdentificationTests extends TestBase {
   @Test
   public void testDeIdentifyTableRowSuppress() throws IOException {
     // Suppress a row based on the content of a column
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .build())
-        .build();
-    Table expectedTable = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .build())
+            .build();
+    Table expectedTable =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .build())
+            .build();
 
-    Table table = DeIdentifyTableRowSuppress.deIdentifyTableRowSuppress(
-        PROJECT_ID, tableToDeIdentify);
+    Table table =
+        DeIdentifyTableRowSuppress.deIdentifyTableRowSuppress(PROJECT_ID, tableToDeIdentify);
 
     String output = bout.toString();
     assertThat(output).contains("Table after de-identification:");
@@ -349,61 +398,80 @@ public class DeIdentificationTests extends TestBase {
   @Test
   public void testDeIdentifyTableConditionsInfoTypes() throws IOException {
     // Transform findings only when specific conditions are met on another field
-    Table tableToDeIdentify = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "Charles Dickens name was a curse, possibly invented by Shakespeare.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "There are 14 kisses in Jane Austen's novels.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
-            .build())
-        .build();
-    Table expectedTable = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("AGE").build())
-        .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
-        .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
-        .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("101").build())
-            .addValues(Value.newBuilder().setStringValue("[PERSON_NAME]").build())
-            .addValues(Value.newBuilder().setStringValue("95").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "[PERSON_NAME] name was a curse, possibly invented by Shakespeare.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("22").build())
-            .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
-            .addValues(Value.newBuilder().setStringValue("21").build())
-            .addValues(Value.newBuilder().setStringValue(
-                "There are 14 kisses in Jane Austen's novels.").build())
-            .build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("55").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
-            .addValues(Value.newBuilder().setStringValue("75").build())
-            .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
-            .build())
-        .build();
+    Table tableToDeIdentify =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("Charles Dickens").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue(
+                                "Charles Dickens name was a curse, possibly invented by Shakespeare.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue("There are 14 kisses in Jane Austen's novels.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
+                    .build())
+            .build();
+    Table expectedTable =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("AGE").build())
+            .addHeaders(FieldId.newBuilder().setName("PATIENT").build())
+            .addHeaders(FieldId.newBuilder().setName("HAPPINESS SCORE").build())
+            .addHeaders(FieldId.newBuilder().setName("FACTOID").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("101").build())
+                    .addValues(Value.newBuilder().setStringValue("[PERSON_NAME]").build())
+                    .addValues(Value.newBuilder().setStringValue("95").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue(
+                                "[PERSON_NAME] name was a curse, possibly invented by Shakespeare.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("22").build())
+                    .addValues(Value.newBuilder().setStringValue("Jane Austen").build())
+                    .addValues(Value.newBuilder().setStringValue("21").build())
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue("There are 14 kisses in Jane Austen's novels.")
+                            .build())
+                    .build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("55").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain").build())
+                    .addValues(Value.newBuilder().setStringValue("75").build())
+                    .addValues(Value.newBuilder().setStringValue("Mark Twain loved cats.").build())
+                    .build())
+            .build();
 
-    Table table = DeIdentifyTableConditionInfoTypes.deIdentifyTableConditionInfoTypes(
-        PROJECT_ID, tableToDeIdentify);
+    Table table =
+        DeIdentifyTableConditionInfoTypes.deIdentifyTableConditionInfoTypes(
+            PROJECT_ID, tableToDeIdentify);
 
     String output = bout.toString();
     assertThat(output).contains("Table after de-identification:");
@@ -428,34 +496,32 @@ public class DeIdentificationTests extends TestBase {
   @Test
   public void testDeIdentifyWithRedaction() throws IOException {
     DeIdentifyWithRedaction.deIdentifyWithRedaction(
-        PROJECT_ID,
-        "My name is Alicia Abernathy, and my email address is aabernathy@example.com.");
+        PROJECT_ID, "My name is Alicia Abernathy, and my email address is aabernathy@example.com.");
 
     String output = bout.toString();
-    assertThat(output).contains("Text after redaction: "
-        + "My name is Alicia Abernathy, and my email address is .");
+    assertThat(output)
+        .contains(
+            "Text after redaction: " + "My name is Alicia Abernathy, and my email address is .");
   }
 
   @Test
   public void testDeIdentifyWithReplacement() throws IOException {
     DeIdentifyWithReplacement.deIdentifyWithReplacement(
-        PROJECT_ID,
-        "My name is Alicia Abernathy, and my email address is aabernathy@example.com.");
+        PROJECT_ID, "My name is Alicia Abernathy, and my email address is aabernathy@example.com.");
 
     String output = bout.toString();
-    assertThat(output).contains("Text after redaction: "
-        + "My name is Alicia Abernathy, and my email address is [email-address].");
+    assertThat(output)
+        .contains(
+            "Text after redaction: "
+                + "My name is Alicia Abernathy, and my email address is [email-address].");
   }
 
   @Test
   public void testDeIdentifyWithInfoType() throws IOException {
-    DeIdentifyWithInfoType.deIdentifyWithInfoType(
-        PROJECT_ID,
-        "My email is test@example.com");
+    DeIdentifyWithInfoType.deIdentifyWithInfoType(PROJECT_ID, "My email is test@example.com");
 
     String output = bout.toString();
-    assertThat(output).contains("Text after redaction: "
-        + "My email is [EMAIL_ADDRESS]");
+    assertThat(output).contains("Text after redaction: " + "My email is [EMAIL_ADDRESS]");
   }
 
   @Test

--- a/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
@@ -311,7 +311,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "[PERSON_NAME] name was a curse, possibly invented by Shakespeare.")
+                                "[PERSON_NAME] name was a curse invented by Shakespeare.")
                             .build())
                     .build())
             .addRows(

--- a/samples/snippets/src/test/java/dlp/snippets/InspectTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/InspectTests.java
@@ -46,18 +46,22 @@ public class InspectTests extends TestBase {
   private static final String DOCUMENT_INPUT_FILE = "src/test/resources/sensitive-data-image.jpg";
 
   private UUID testRunUuid = UUID.randomUUID();
-  private TopicName topicName = TopicName.of(
-      PROJECT_ID,
-      String.format("%s-%s", TOPIC_ID, testRunUuid.toString()));
-  private ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(
-      PROJECT_ID,
-      String.format("%s-%s", SUBSCRIPTION_ID, testRunUuid.toString()));
+  private TopicName topicName =
+      TopicName.of(PROJECT_ID, String.format("%s-%s", TOPIC_ID, testRunUuid.toString()));
+  private ProjectSubscriptionName subscriptionName =
+      ProjectSubscriptionName.of(
+          PROJECT_ID, String.format("%s-%s", SUBSCRIPTION_ID, testRunUuid.toString()));
 
   @Override
   protected ImmutableList<String> requiredEnvVars() {
-    return ImmutableList
-        .of("GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "GCS_PATH", "PUB_SUB_TOPIC",
-            "PUB_SUB_SUBSCRIPTION", "BIGQUERY_DATASET", "BIGQUERY_TABLE");
+    return ImmutableList.of(
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "GCS_PATH",
+        "PUB_SUB_TOPIC",
+        "PUB_SUB_SUBSCRIPTION",
+        "BIGQUERY_DATASET",
+        "BIGQUERY_TABLE");
   }
 
   @Before
@@ -69,11 +73,10 @@ public class InspectTests extends TestBase {
 
     // Create a new subscription
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
-      subscriptionAdminClient
-          .createSubscription(subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
+      subscriptionAdminClient.createSubscription(
+          subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
     }
   }
-
 
   @After
   public void after() throws Exception {
@@ -81,8 +84,7 @@ public class InspectTests extends TestBase {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(topicName);
     } catch (ApiException e) {
-      System.err.println(String.format("Error deleting topic %s: %s",
-          topicName.getTopic(), e));
+      System.err.println(String.format("Error deleting topic %s: %s", topicName.getTopic(), e));
       // Keep trying to clean up
     }
 
@@ -90,8 +92,9 @@ public class InspectTests extends TestBase {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       subscriptionAdminClient.deleteSubscription(subscriptionName);
     } catch (ApiException e) {
-      System.err.println(String.format("Error deleting subscription %s: %s",
-          subscriptionName.getSubscription(), e));
+      System.err.println(
+          String.format(
+              "Error deleting subscription %s: %s", subscriptionName.getSubscription(), e));
       // Keep trying to clean up
     }
   }
@@ -123,7 +126,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringWithExclusionDict() throws Exception {
-    InspectStringWithExclusionDict.inspectStringWithExclusionDict(PROJECT_ID,
+    InspectStringWithExclusionDict.inspectStringWithExclusionDict(
+        PROJECT_ID,
         "Some email addresses: gary@example.com, example@example.com",
         Arrays.asList("example@example.com"));
 
@@ -134,7 +138,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringWithExclusionDictSubstring() throws Exception {
-    InspectStringWithExclusionDictSubstring.inspectStringWithExclusionDictSubstring(PROJECT_ID,
+    InspectStringWithExclusionDictSubstring.inspectStringWithExclusionDictSubstring(
+        PROJECT_ID,
         "Some email addresses: gary@example.com, TEST@example.com",
         Arrays.asList("TEST"));
 
@@ -145,9 +150,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringWithExclusionRegex() throws Exception {
-    InspectStringWithExclusionRegex.inspectStringWithExclusionRegex(PROJECT_ID,
-        "Some email addresses: gary@example.com, bob@example.org",
-        ".+@example.com");
+    InspectStringWithExclusionRegex.inspectStringWithExclusionRegex(
+        PROJECT_ID, "Some email addresses: gary@example.com, bob@example.org", ".+@example.com");
 
     String output = bout.toString();
     assertThat(output).contains("bob@example.org");
@@ -156,7 +160,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringCustomExcludingSubstring() throws Exception {
-    InspectStringCustomExcludingSubstring.inspectStringCustomExcludingSubstring(PROJECT_ID,
+    InspectStringCustomExcludingSubstring.inspectStringCustomExcludingSubstring(
+        PROJECT_ID,
         "Name: Doe, John. Name: Example, Jimmy",
         "[A-Z][a-z]{1,15}, [A-Z][a-z]{1,15}",
         Arrays.asList("Jimmy"));
@@ -168,8 +173,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringCustomOmitOverlap() throws Exception {
-    InspectStringCustomOmitOverlap.inspectStringCustomOmitOverlap(PROJECT_ID,
-        "Name: Jane Doe. Name: Larry Page.");
+    InspectStringCustomOmitOverlap.inspectStringCustomOmitOverlap(
+        PROJECT_ID, "Name: Jane Doe. Name: Larry Page.");
 
     String output = bout.toString();
     assertThat(output).contains("Jane Doe");
@@ -187,8 +192,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringWithoutOverlap() throws Exception {
-    InspectStringWithoutOverlap.inspectStringWithoutOverlap(PROJECT_ID,
-        "example.com is a domain, james@example.org is an email.");
+    InspectStringWithoutOverlap.inspectStringWithoutOverlap(
+        PROJECT_ID, "example.com is a domain, james@example.org is an email.");
 
     String output = bout.toString();
     assertThat(output).contains("example.com");
@@ -197,13 +202,15 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectTable() {
-    Table tableToInspect = Table.newBuilder()
-        .addHeaders(FieldId.newBuilder().setName("name").build())
-        .addHeaders(FieldId.newBuilder().setName("phone").build())
-        .addRows(Row.newBuilder()
-            .addValues(Value.newBuilder().setStringValue("John Doe").build())
-            .addValues(Value.newBuilder().setStringValue("(206) 555-0123").build()))
-        .build();
+    Table tableToInspect =
+        Table.newBuilder()
+            .addHeaders(FieldId.newBuilder().setName("name").build())
+            .addHeaders(FieldId.newBuilder().setName("phone").build())
+            .addRows(
+                Row.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("John Doe").build())
+                    .addValues(Value.newBuilder().setStringValue("(206) 555-0123").build()))
+            .build();
     InspectTable.inspectTable(PROJECT_ID, tableToInspect);
 
     String output = bout.toString();
@@ -212,8 +219,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringCustomHotword() throws Exception {
-    InspectStringCustomHotword.inspectStringCustomHotword(PROJECT_ID,
-        "patient name: John Doe", "patient");
+    InspectStringCustomHotword.inspectStringCustomHotword(
+        PROJECT_ID, "patient name: John Doe", "patient");
 
     String output = bout.toString();
     assertThat(output).contains("John Doe");
@@ -221,8 +228,7 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringCustomHotwordNegativeExample() throws Exception {
-    InspectStringCustomHotword.inspectStringCustomHotword(PROJECT_ID,
-        "name: John Doe", "patient");
+    InspectStringCustomHotword.inspectStringCustomHotword(PROJECT_ID, "name: John Doe", "patient");
 
     String output = bout.toString();
     assertThat(output).doesNotContain("John Doe");
@@ -230,8 +236,7 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringMultipleRulesPatientRule() throws Exception {
-    InspectStringMultipleRules.inspectStringMultipleRules(PROJECT_ID,
-        "patient name: Jane Doe");
+    InspectStringMultipleRules.inspectStringMultipleRules(PROJECT_ID, "patient name: Jane Doe");
 
     String output = bout.toString();
     assertThat(output).contains("LIKELY");
@@ -239,8 +244,7 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringMultipleRulesDoctorRule() throws Exception {
-    InspectStringMultipleRules.inspectStringMultipleRules(PROJECT_ID,
-        "doctor: Jane Doe");
+    InspectStringMultipleRules.inspectStringMultipleRules(PROJECT_ID, "doctor: Jane Doe");
 
     String output = bout.toString();
     assertThat(output).contains("Findings: 0");
@@ -248,8 +252,7 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringMultipleRulesQuasimodoRule() throws Exception {
-    InspectStringMultipleRules.inspectStringMultipleRules(PROJECT_ID,
-        "patient: Quasimodo");
+    InspectStringMultipleRules.inspectStringMultipleRules(PROJECT_ID, "patient: Quasimodo");
 
     String output = bout.toString();
     assertThat(output).contains("Findings: 0");
@@ -257,8 +260,7 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectStringMultipleRulesRedactedRule() throws Exception {
-    InspectStringMultipleRules.inspectStringMultipleRules(PROJECT_ID,
-        "name of patient: REDACTED");
+    InspectStringMultipleRules.inspectStringMultipleRules(PROJECT_ID, "name of patient: REDACTED");
 
     String output = bout.toString();
     assertThat(output).contains("Findings: 0");
@@ -304,9 +306,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectGcsFile() throws Exception {
-    InspectGcsFile
-        .inspectGcsFile(PROJECT_ID, GCS_PATH, topicName.getTopic(),
-            subscriptionName.getSubscription());
+    InspectGcsFile.inspectGcsFile(
+        PROJECT_ID, GCS_PATH, topicName.getTopic(), subscriptionName.getSubscription());
 
     String output = bout.toString();
     assertThat(output).contains("Job status: DONE");
@@ -314,9 +315,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectGcsFileWithSampling() throws Exception {
-    InspectGcsFileWithSampling
-        .inspectGcsFileWithSampling(PROJECT_ID, GCS_PATH, topicName.getTopic(),
-            subscriptionName.getSubscription());
+    InspectGcsFileWithSampling.inspectGcsFileWithSampling(
+        PROJECT_ID, GCS_PATH, topicName.getTopic(), subscriptionName.getSubscription());
 
     String output = bout.toString();
     assertThat(output).contains("Job status: DONE");
@@ -324,9 +324,12 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectDatastoreEntity() throws Exception {
-    InspectDatastoreEntity
-        .insepctDatastoreEntity(PROJECT_ID, datastoreNamespace, datastoreKind, topicName.getTopic(),
-            subscriptionName.getSubscription());
+    InspectDatastoreEntity.insepctDatastoreEntity(
+        PROJECT_ID,
+        datastoreNamespace,
+        datastoreKind,
+        topicName.getTopic(),
+        subscriptionName.getSubscription());
 
     String output = bout.toString();
     assertThat(output).contains("Job status: DONE");
@@ -334,9 +337,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectBigQueryTable() throws Exception {
-    InspectBigQueryTable
-        .inspectBigQueryTable(PROJECT_ID, DATASET_ID, TABLE_ID, topicName.getTopic(),
-            subscriptionName.getSubscription());
+    InspectBigQueryTable.inspectBigQueryTable(
+        PROJECT_ID, DATASET_ID, TABLE_ID, topicName.getTopic(), subscriptionName.getSubscription());
 
     String output = bout.toString();
     assertThat(output).contains("Job status: DONE");
@@ -344,9 +346,8 @@ public class InspectTests extends TestBase {
 
   @Test
   public void testInspectBigQueryTableWithSampling() throws Exception {
-    InspectBigQueryTableWithSampling
-        .inspectBigQueryTableWithSampling(PROJECT_ID, topicName.getTopic(),
-            subscriptionName.getSubscription());
+    InspectBigQueryTableWithSampling.inspectBigQueryTableWithSampling(
+        PROJECT_ID, topicName.getTopic(), subscriptionName.getSubscription());
 
     String output = bout.toString();
     assertThat(output).contains("Job status: DONE");

--- a/samples/snippets/src/test/java/dlp/snippets/RedactTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/RedactTests.java
@@ -32,10 +32,8 @@ public class RedactTests extends TestBase {
 
   private static final String SIMPLE_INPUT_FILE = "src/test/resources/test.png";
   private static final String SIMPLE_OUTPUT_FILE = "redacted.png";
-  private static final String DOCUMENT_INPUT_FILE =
-      "src/test/resources/sensitive-data-image.jpg";
-  private static final String DOCUMENT_OUTPUT_FILE =
-      "sensitive-data-image-redacted.jpg";
+  private static final String DOCUMENT_INPUT_FILE = "src/test/resources/sensitive-data-image.jpg";
+  private static final String DOCUMENT_OUTPUT_FILE = "sensitive-data-image-redacted.jpg";
 
   @Override
   protected ImmutableList<String> requiredEnvVars() {
@@ -58,8 +56,8 @@ public class RedactTests extends TestBase {
 
   @Test
   public void testRedactImageAllInfoTypes() throws Exception {
-    RedactImageFileAllInfoTypes.redactImageFileAllInfoTypes(PROJECT_ID, DOCUMENT_INPUT_FILE,
-        DOCUMENT_OUTPUT_FILE);
+    RedactImageFileAllInfoTypes.redactImageFileAllInfoTypes(
+        PROJECT_ID, DOCUMENT_INPUT_FILE, DOCUMENT_OUTPUT_FILE);
 
     String output = bout.toString();
     assertThat(output).contains("Redacted image written");
@@ -67,8 +65,8 @@ public class RedactTests extends TestBase {
 
   @Test
   public void testRedactImageListedInfoTypes() throws Exception {
-    RedactImageFileListedInfoTypes.redactImageFileListedInfoTypes(PROJECT_ID, DOCUMENT_INPUT_FILE,
-        DOCUMENT_OUTPUT_FILE);
+    RedactImageFileListedInfoTypes.redactImageFileListedInfoTypes(
+        PROJECT_ID, DOCUMENT_INPUT_FILE, DOCUMENT_OUTPUT_FILE);
 
     String output = bout.toString();
     assertThat(output).contains("Redacted image written");
@@ -76,8 +74,8 @@ public class RedactTests extends TestBase {
 
   @Test
   public void testRedactImageColoredInfoTypes() throws Exception {
-    RedactImageFileColoredInfoTypes.redactImageFileColoredInfoTypes(PROJECT_ID, DOCUMENT_INPUT_FILE,
-        DOCUMENT_OUTPUT_FILE);
+    RedactImageFileColoredInfoTypes.redactImageFileColoredInfoTypes(
+        PROJECT_ID, DOCUMENT_INPUT_FILE, DOCUMENT_OUTPUT_FILE);
 
     String output = bout.toString();
     assertThat(output).contains("Redacted image written");
@@ -85,8 +83,8 @@ public class RedactTests extends TestBase {
 
   @Test
   public void testRedactImageAllText() throws Exception {
-    RedactImageFileAllText.redactImageFileAllText(PROJECT_ID, DOCUMENT_INPUT_FILE,
-        DOCUMENT_OUTPUT_FILE);
+    RedactImageFileAllText.redactImageFileAllText(
+        PROJECT_ID, DOCUMENT_INPUT_FILE, DOCUMENT_OUTPUT_FILE);
 
     String output = bout.toString();
     assertThat(output).contains("Redacted image written");

--- a/samples/snippets/src/test/java/dlp/snippets/RiskAnalysisTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/RiskAnalysisTests.java
@@ -36,18 +36,21 @@ import org.junit.runners.JUnit4;
 public class RiskAnalysisTests extends TestBase {
 
   private UUID testRunUuid = UUID.randomUUID();
-  private TopicName topicName = TopicName.of(
-      PROJECT_ID,
-      String.format("%s-%s", TOPIC_ID, testRunUuid.toString()));
-  private ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(
-      PROJECT_ID,
-      String.format("%s-%s", SUBSCRIPTION_ID, testRunUuid.toString()));
+  private TopicName topicName =
+      TopicName.of(PROJECT_ID, String.format("%s-%s", TOPIC_ID, testRunUuid.toString()));
+  private ProjectSubscriptionName subscriptionName =
+      ProjectSubscriptionName.of(
+          PROJECT_ID, String.format("%s-%s", SUBSCRIPTION_ID, testRunUuid.toString()));
 
   @Override
   protected ImmutableList<String> requiredEnvVars() {
-    return ImmutableList
-        .of("GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "PUB_SUB_TOPIC",
-            "PUB_SUB_SUBSCRIPTION", "BIGQUERY_DATASET", "BIGQUERY_TABLE");
+    return ImmutableList.of(
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "PUB_SUB_TOPIC",
+        "PUB_SUB_SUBSCRIPTION",
+        "BIGQUERY_DATASET",
+        "BIGQUERY_TABLE");
   }
 
   @Before
@@ -58,8 +61,8 @@ public class RiskAnalysisTests extends TestBase {
     }
     // Create a new subscription
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
-      subscriptionAdminClient
-          .createSubscription(subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
+      subscriptionAdminClient.createSubscription(
+          subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
     }
   }
 
@@ -69,8 +72,7 @@ public class RiskAnalysisTests extends TestBase {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(topicName);
     } catch (ApiException e) {
-      System.err.println(String.format("Error deleting topic %s: %s",
-          topicName.getTopic(), e));
+      System.err.println(String.format("Error deleting topic %s: %s", topicName.getTopic(), e));
       // Keep trying to clean up
     }
 
@@ -78,8 +80,9 @@ public class RiskAnalysisTests extends TestBase {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       subscriptionAdminClient.deleteSubscription(subscriptionName);
     } catch (ApiException e) {
-      System.err.println(String.format("Error deleting subscription %s: %s",
-          subscriptionName.getSubscription(), e));
+      System.err.println(
+          String.format(
+              "Error deleting subscription %s: %s", subscriptionName.getSubscription(), e));
       // Keep trying to clean up
     }
   }

--- a/samples/snippets/src/test/java/dlp/snippets/TestBase.java
+++ b/samples/snippets/src/test/java/dlp/snippets/TestBase.java
@@ -24,9 +24,7 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 
-/**
- * Common base class for DLP snippet tests
- */
+/** Common base class for DLP snippet tests */
 abstract class TestBase {
 
   protected static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
@@ -45,8 +43,9 @@ abstract class TestBase {
 
   private static void requireEnvVar(String varName) {
     assertWithMessage(
-        String.format("Environment variable '%s' must be set to perform these tests.", varName))
-        .that(System.getenv(varName)).isNotEmpty();
+            String.format("Environment variable '%s' must be set to perform these tests.", varName))
+        .that(System.getenv(varName))
+        .isNotEmpty();
   }
 
   @Before


### PR DESCRIPTION
This PR contains : 

1. Override default TotalTimeOut of `DlpServiceClient`, Set `PT10M(600 seconds)` instead `PT5M(300 seconds)` to prevent flaky failures.

2. Run the code formatter `mvn com.coveo:fmt-maven-plugin:format` to fix the `DLP `samples format's



Fixes #273 
