### PR TITLE
fix: suppress checkstyle for certain methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.4.0')
+implementation platform('com.google.cloud:libraries-bom:26.0.0')
 
 implementation 'com.google.cloud:google-cloud-dlp'
 ```

--- a/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisCategoricalStats.java
+++ b/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisCategoricalStats.java
@@ -15,6 +15,7 @@
  */
 
 package dlp.snippets;
+
 // [START dlp_categorical_stats]
 
 import com.google.api.core.SettableApiFuture;

--- a/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java
+++ b/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 class RiskAnalysisKAnonymity {
 
   public static void main(String[] args) throws Exception {

--- a/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisKMap.java
+++ b/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisKMap.java
@@ -15,6 +15,7 @@
  */
 
 package dlp.snippets;
+
 // [START dlp_k_map]
 
 import com.google.api.core.SettableApiFuture;

--- a/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisKMap.java
+++ b/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisKMap.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 class RiskAnalysisKMap {
 
   public static void main(String[] args) throws Exception {

--- a/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
+++ b/samples/snippets/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
@@ -52,6 +52,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.threeten.bp.Duration;
 
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 class RiskAnalysisLDiversity {
 
   public static void main(String[] args) throws Exception {

--- a/samples/snippets/src/test/java/dlp/snippets/RiskAnalysisTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/RiskAnalysisTests.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @RunWith(JUnit4.class)
 public class RiskAnalysisTests extends TestBase {
 


### PR DESCRIPTION
Some PRs are failing checkstyle tests:

```
Error:  src/main/java/dlp/snippets/RiskAnalysisKMap.java:[18,1] (whitespace) EmptyLineSeparator: '//' should be separated from previous line.
Error:  src/main/java/dlp/snippets/RiskAnalysisKMap.java:[53,7] (naming) AbbreviationAsWordInName: Abbreviation in name 'RiskAnalysisKMap' must contain no more than '1' consecutive capital letters.
Error:  src/main/java/dlp/snippets/RiskAnalysisKMap.java:[65,22] (naming) AbbreviationAsWordInName: Abbreviation in name 'calculateKMap' must contain no more than '1' consecutive capital letters.
Error:  src/main/java/dlp/snippets/RiskAnalysisLDiversity.java:[55,7] (naming) AbbreviationAsWordInName: Abbreviation in name 'RiskAnalysisLDiversity' must contain no more than '1' consecutive capital letters.
Error:  src/main/java/dlp/snippets/RiskAnalysisLDiversity.java:[67,22] (naming) AbbreviationAsWordInName: Abbreviation in name 'calculateLDiversity' must contain no more than '1' consecutive capital letters.
Error:  src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java:[52,7] (naming) AbbreviationAsWordInName: Abbreviation in name 'RiskAnalysisKAnonymity' must contain no more than '1' consecutive capital letters.
Error:  src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java:[64,22] (naming) AbbreviationAsWordInName: Abbreviation in name 'calculateKAnonymity' must contain no more than '1' consecutive capital letters.
``

This updates the empty line error, and suppresses the Checkstyle check for methods that are correctly formatted in camelCase. 