### PR TITLE
fix: update DeIdentificationTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>26.1.0</version>
+      <version>26.1.1</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.1.0')
+implementation platform('com.google.cloud:libraries-bom:26.1.1')
 
 implementation 'com.google.cloud:google-cloud-dlp'
 ```

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -30,7 +30,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.1.0</version>
+        <version>26.1.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
@@ -311,7 +311,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "[PERSON_NAME] name was a curse invented by Shakespeare.")
+                                "[PERSON_NAME] name was a curse invented by [PERSON_NAME].")
                             .build())
                     .build())
             .addRows(
@@ -447,7 +447,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "[PERSON_NAME] name was a curse invented by Shakespeare.")
+                                "[PERSON_NAME] name was a curse invented by [PERSON_NAME].")
                             .build())
                     .build())
             .addRows(

--- a/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
@@ -275,7 +275,8 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(Value.newBuilder().setStringValue("95").build())
                     .addValues(
                         Value.newBuilder()
-                            .setStringValue("Charles Dickens name was a curse invented by a bard.")
+                            .setStringValue(
+                                "Charles Dickens name was a curse invented by Shakespeare.")
                             .build())
                     .build())
             .addRows(
@@ -309,7 +310,8 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(Value.newBuilder().setStringValue("95").build())
                     .addValues(
                         Value.newBuilder()
-                            .setStringValue("[PERSON_NAME] name was a curse invented by a bard.")
+                            .setStringValue(
+                                "[PERSON_NAME] name was a curse invented by [PERSON_NAME].")
                             .build())
                     .build())
             .addRows(
@@ -409,7 +411,8 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(Value.newBuilder().setStringValue("95").build())
                     .addValues(
                         Value.newBuilder()
-                            .setStringValue("Charles Dickens name was a curse invented by a bard.")
+                            .setStringValue(
+                                "Charles Dickens name was a curse invented by Shakespeare.")
                             .build())
                     .build())
             .addRows(
@@ -443,7 +446,8 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(Value.newBuilder().setStringValue("95").build())
                     .addValues(
                         Value.newBuilder()
-                            .setStringValue("[PERSON_NAME] name was a curse invented by a bard.")
+                            .setStringValue(
+                                "[PERSON_NAME] name was a curse invented by [PERSON_NAME].")
                             .build())
                     .build())
             .addRows(

--- a/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
@@ -275,8 +275,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(Value.newBuilder().setStringValue("95").build())
                     .addValues(
                         Value.newBuilder()
-                            .setStringValue(
-                                "Charles Dickens name was a curse invented by a bard.")
+                            .setStringValue("Charles Dickens name was a curse invented by a bard.")
                             .build())
                     .build())
             .addRows(
@@ -310,8 +309,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(Value.newBuilder().setStringValue("95").build())
                     .addValues(
                         Value.newBuilder()
-                            .setStringValue(
-                                "[PERSON_NAME] name was a curse invented by a bard.")
+                            .setStringValue("[PERSON_NAME] name was a curse invented by a bard.")
                             .build())
                     .build())
             .addRows(
@@ -411,8 +409,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(Value.newBuilder().setStringValue("95").build())
                     .addValues(
                         Value.newBuilder()
-                            .setStringValue(
-                                "Charles Dickens name was a curse invented by a bard.")
+                            .setStringValue("Charles Dickens name was a curse invented by a bard.")
                             .build())
                     .build())
             .addRows(
@@ -446,8 +443,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(Value.newBuilder().setStringValue("95").build())
                     .addValues(
                         Value.newBuilder()
-                            .setStringValue(
-                                "[PERSON_NAME] name was a curse invented by a bard.")
+                            .setStringValue("[PERSON_NAME] name was a curse invented by a bard.")
                             .build())
                     .build())
             .addRows(

--- a/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
@@ -276,7 +276,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "Charles Dickens name was a curse invented by Shakespeare.")
+                                "Charles Dickens name was a curse invented by adieu.")
                             .build())
                     .build())
             .addRows(

--- a/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
+++ b/samples/snippets/src/test/java/dlp/snippets/DeIdentificationTests.java
@@ -276,7 +276,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "Charles Dickens name was a curse invented by adieu.")
+                                "Charles Dickens name was a curse invented by a bard.")
                             .build())
                     .build())
             .addRows(
@@ -311,7 +311,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "[PERSON_NAME] name was a curse invented by [PERSON_NAME].")
+                                "[PERSON_NAME] name was a curse invented by a bard.")
                             .build())
                     .build())
             .addRows(
@@ -412,7 +412,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "Charles Dickens name was a curse invented by Shakespeare.")
+                                "Charles Dickens name was a curse invented by a bard.")
                             .build())
                     .build())
             .addRows(
@@ -447,7 +447,7 @@ public class DeIdentificationTests extends TestBase {
                     .addValues(
                         Value.newBuilder()
                             .setStringValue(
-                                "[PERSON_NAME] name was a curse invented by [PERSON_NAME].")
+                                "[PERSON_NAME] name was a curse invented by a bard.")
                             .build())
                     .build())
             .addRows(


### PR DESCRIPTION
Fixes #971, #972 ☕️

My best guess is that "Shakespeare" recently got added into a dictionary this API uses as a "PERSON_NAME", so the test needed to be updated. I confirmed this by testing on the API explorer here: https://cloud.google.com/dlp/docs/reference/rest/v2/projects.content/deidentify